### PR TITLE
セッションに関連するガチャ結果を受け取れるようにしました

### DIFF
--- a/laravel/app/Http/Controllers/ClatterResultController.php
+++ b/laravel/app/Http/Controllers/ClatterResultController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\DustBox;
+use App\Models\Session;
+use App\Models\User;
+
+class ClatterResultController extends Controller
+{
+    public function index($dustBoxId, $sessionId, Request $request)
+    {
+        $user = Auth::user();
+        $session = Session::where('dust_box_id', $dustBoxId)
+            ->where('user_id', $user->id)
+            ->orderBy('created_at', 'desc')
+            ->firstOrFail();
+        return $session->clatterResults()->get();
+    }
+}

--- a/laravel/app/Models/ClatterResult.php
+++ b/laravel/app/Models/ClatterResult.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Costume;
 
 class ClatterResult extends Model
 {
@@ -11,9 +12,10 @@ class ClatterResult extends Model
 
     protected $fillable = ["user_id", "costume_id", "session_id", "earn_exp"];
 
-    protected $primaryKey = "session_id";
 
     protected $appends = ["type"];
+
+    protected $with = ['costume'];
 
     public function getTypeAttribute()
     {
@@ -22,5 +24,10 @@ class ClatterResult extends Model
         } else {
             return "exp";
         }
+    }
+
+    public function costume()
+    {
+        return $this->belongsTo(Costume::class);
     }
 }

--- a/laravel/app/Models/Session.php
+++ b/laravel/app/Models/Session.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\User;
+use App\Models\ClatterResult;
 
 class Session extends Model
 {
@@ -16,4 +17,11 @@ class Session extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function clatterResults()
+    {
+        return $this->hasMany(ClatterResult::class);
+    }
+
+    
 }

--- a/laravel/database/migrations/2022_06_11_130237_create_clatter_results_table.php
+++ b/laravel/database/migrations/2022_06_11_130237_create_clatter_results_table.php
@@ -13,6 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::create("clatter_results", function (Blueprint $table) {
+            $table->id();
             $table->unsignedBigInteger("session_id");
             $table->unsignedBigInteger("costume_id")->nullable();
             $table->integer("earn_exp")->default(0);

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\SessionController;
 use App\Http\Controllers\MyCostumeController;
-
+use App\Http\Controllers\ClatterResultController;
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -37,5 +37,6 @@ Route::middleware("auth:sanctum")->group(function () {
         SessionController::class,
         "complete",
     ]);
+    Route::get("/dust-boxes/{dustBoxId}/sessions/{sessionId}/clatter-results", [ClatterResultController::class, 'index']);
 });
 Route::post("/iot/dust-box-pushes", [SessionController::class, "pushes"]);


### PR DESCRIPTION
# issues
Closed #70

# 説明
GET /dust-boxes/{dustBoxId}/sessions/{sessionId}/clatter-resultsから、
セッションに関連するガチャ結果を、
受け取れるようにしました。　
またClatterResultに主キーが設定されていなかったので、
代理種キーとして主キーを設定するよにしました。
そのためMigrationに破壊的変更がかかります。


# 確認したこと
Postmanで動作することを確認しました。
- セッションを開始できることを確認しました
- ゴミを入れられることを確認しました
- 上記エンドポイントからガチャの結果を受け取れることを確認しました